### PR TITLE
openPMD improvements

### DIFF
--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -25,7 +25,7 @@ class ParametersBase(JSONSerializable):
     def __init__(self,):
         super(ParametersBase, self).__init__()
         self._configuration = {"gpu": False, "horovod": False, "mpi": False,
-                               "device": "cpu", "openpmd_configuration": "{}"}
+                               "device": "cpu", "openpmd_configuration": {}}
         pass
 
     def show(self, indent=""):
@@ -1088,7 +1088,7 @@ class Parameters:
         self.use_mpi = False
         self.verbosity = 1
         self.device = "cpu"
-        self.openpmd_configuration = "{}"
+        self.openpmd_configuration = {}
 
     @property
     def verbosity(self):

--- a/mala/common/physical_data.py
+++ b/mala/common/physical_data.py
@@ -1,6 +1,7 @@
 """Base class for all calculators that deal with physical data"""
 from abc import ABC, abstractmethod
 
+import json
 import numpy as np
 import openpmd_api as io
 
@@ -96,7 +97,10 @@ class PhysicalData(ABC):
 
         """
         series = io.Series(path, io.Access.read_only,
-                           options=self.parameters._configuration["openpmd_configuration"])
+                           options=json.dumps(
+                                {"defer_iteration_parsing": True} |
+                                self.parameters.
+                                    _configuration["openpmd_configuration"]))
 
         # Check if this actually MALA compatible data.
         if series.get_attribute("is_mala_data") != 1:
@@ -106,6 +110,9 @@ class PhysicalData(ABC):
         # A bit clanky, but this way only the FIRST iteration is loaded,
         # which is what we need for loading from a single file that
         # may be whatever iteration in its series.
+        # Also, in combination with `defer_iteration_parsing`, specified as
+        # default above, this opens and parses the first iteration,
+        # and no others.
         for current_iteration in series.read_iterations():
             mesh = current_iteration.meshes[self.data_name]
             break
@@ -155,7 +162,10 @@ class PhysicalData(ABC):
             Path to the openPMD file.
         """
         series = io.Series(path, io.Access.read_only,
-                           options=self.parameters._configuration["openpmd_configuration"])
+                           options=json.dumps(
+                                {"defer_iteration_parsing": True} |
+                                self.parameters.
+                                    _configuration["openpmd_configuration"]))
 
         # Check if this actually MALA compatible data.
         if series.get_attribute("is_mala_data") != 1:
@@ -165,6 +175,9 @@ class PhysicalData(ABC):
         # A bit clanky, but this way only the FIRST iteration is loaded,
         # which is what we need for loading from a single file that
         # may be whatever iteration in its series.
+        # Also, in combination with `defer_iteration_parsing`, specified as
+        # default above, this opens and parses the first iteration,
+        # and no others.
         for current_iteration in series.read_iterations():
             mesh = current_iteration.meshes[self.data_name]
             return self.\

--- a/mala/datahandling/data_converter.py
+++ b/mala/datahandling/data_converter.py
@@ -1,6 +1,7 @@
 """DataConverter class for converting snapshots into numpy arrays."""
 import os
 
+import json
 import numpy as np
 import openpmd_api as io
 
@@ -203,14 +204,16 @@ class DataConverter:
             input_series = io.Series(os.path.join(save_path,
                                                   series_name+".in.h5"),
                                      io.Access.create,
-                                     options=self.parameters_full.
-                                     openpmd_configuration)
+                                     options=json.dumps(
+                                        self.parameters_full.
+                                            openpmd_configuration))
 
             output_series = io.Series(os.path.join(save_path,
                                                    series_name+".out.h5"),
                                       io.Access.create,
-                                      options=self.parameters_full.
-                                      openpmd_configuration)
+                                      options=json.dumps(
+                                        self.parameters_full.
+                                            openpmd_configuration))
 
             for series in [input_series, output_series]:
                 series.set_attribute("is_mala_data", 1)


### PR DESCRIPTION
1. In writing, and reading, do the SoA <–> AoS conversion blockwise, i.e. do the necessary transposition of numpy arrays for several openPMD record components at once. 
  * greater block size: fewer and more efficient transpositions
  * smaller block size: lower peak memory usage
  I/O efficiency should be mostly unaffected, since each record component is stored/loaded whole. A greater blocksize means fewer flushes, but this should not have a great effect in HDF5. (ADIOS2 BP5 engine could be affected, if specifying flush targets which we currently don't.)
2. Use a Python dict + `json.dumps()` for `openpmd_configuration`. This makes it easier to specify overridable defaults.
3. Specify `{"defer_iteration_parsing": true}` by default. It's potentially more efficient (if a checkpoint with multiple iterations is loaded), and otherwise not harmful.