### PR TITLE
Fix bugs in parallelized openPMD output

### DIFF
--- a/mala/common/physical_data.py
+++ b/mala/common/physical_data.py
@@ -415,7 +415,7 @@ match the array dimensions (extent {} in the feature dimension)""".format(
         # which is something we never do though anyway.
         # Deal with `granularity` items of the vectors at a time
         # Or in the openPMD layout: with `granularity` record components
-        granularity = 16 # just some random value for now
+        granularity = self.parameters._configuration["openpmd_granularity"]
         # Before writing the actual data, we have to make two considerations
         # for MPI:
         # 1) The following loop does not necessarily have the same number of


### PR DESCRIPTION
1. Dataset creation and attribute writing is collective in HDF5
2. Number of flushes was potentially different between ranks, harmonize number of flushes

I compared the output of this PR executed with 1 and with 10 parallel processes against the output from before the parallelization effort, the output is the same.

```python
#!/usr/bin/env python

import numpy as np
import adios2
import sys

file1 = sys.argv[1]
file2 = sys.argv[2]

print("Comparing files", file1, "and", file2)


def compare_numpy_arrays(arr1, arr2, name):
    # delta = np.absolute(arr1 - arr2)
    # print("Mean:", np.mean(delta))
    # print("Median:", np.median(delta))
    # print("Stddev:", np.std(delta))
    try:
        np.testing.assert_allclose(arr1, arr2)
    except AssertionError as e:
        print("Error in array {}:\n{}\n\n".format(name, e))


def compare_steps(s1, s2):
    set1 = set(s1.available_variables())
    set2 = set(s2.available_variables())
    for var in set1.difference(set2):
        print("VAR S1-S2:", var)
    for var in set2.difference(set1):
        print("VAR S2-S1:", var)
    attrs1 = set(s1.available_attributes())
    attrs2 = set(s2.available_attributes())
    for var in attrs1.difference(attrs2):
        print("ATTR S1-S2:", var)
    for var in attrs2.difference(attrs1):
        print("ATTR S2-S1:", var)

    for var in set1.intersection(set2):
        compare_numpy_arrays(s1.read(var), s2.read(var), var)

    for var in attrs1.intersection(attrs2):
        try:
            attr1 = s1.read_attribute(var)
            attr2 = s2.read_attribute(var)
        except ValueError:
            attr1 = s1.read_attribute_string(var)
            attr2 = s2.read_attribute_string(var)
            if attr1 != attr2 and var != "/date":
                print(
                    "String attribute '{}' is not equal: '{}' != '{}'".format(
                        var, attr1, attr2))
            continue
        compare_numpy_arrays(attr1, attr2, var)


def compare_files(f1, f2):
    pass
    iter1 = f1.__iter__()
    iter2 = f2.__iter__()
    while True:
        try:
            it1 = iter1.__next__()
            it2 = iter2.__next__()
        except StopIteration:
            break
        compare_steps(it1, it2)


with adios2.open(file1, "r") as f1, adios2.open(file2, "r") as f2:
    compare_files(f1, f2)
```

```bash
arr=(./training_data_temp_mpi ./training_data_temp_mpisingle/ ./training_data_temp_nompi/)
for i in `seq 0 2`; do 
    for j in `seq $((i+1)) 2`; do 
        for it in 0 1; do
            for io in "in" out; do 
                python3 adios2-compare-files.py "${arr[i]}/Be_snapshot$it.$io.bp" "${arr[j]}/Be_snapshot$it.$io.bp"
            done
        done
    done
done
```