### PR TITLE
Fix TEM build using f2py's meson backend

### DIFF
--- a/external_modules/total_energy_module/build_total_energy_module.sh
+++ b/external_modules/total_energy_module/build_total_energy_module.sh
@@ -9,6 +9,23 @@ err(){
 
 [ $# -eq 1 ] || err "Please provide exactly one argument (the path to the QE directory)" && root_dir=$1
 
+
+# ----------------------------------------------------------------------------
+# Settings to adapt to your machine
+# ----------------------------------------------------------------------------
+
+# default: system blas,lapack and fftw, adapt as needed
+linalg="-lblas -llapack"
+fftw="-lfftw3"
+
+# This is for OpenMPI. Intel MPI's compiler wrappers are called mpiifort and
+# mpiicc. Both libraries provide other aliases like mpif90 and mpicc.
+f_compiler="mpifort"
+c_compiler="mpicc"
+
+# ----------------------------------------------------------------------------
+
+
 echo "Using QE root dir: $root_dir"
 
 pw_src_path=$root_dir/PW/src
@@ -39,10 +56,6 @@ qe_libs="-lqemod -lks_solvers -lqefft -lqela -lutil -ldftd3qe -lupf -ldevXlib -l
 echo "qe_lib_dirs: $qe_lib_dirs"
 echo "qe_inc_dirs: $qe_inc_dirs"
 
-# default: system blas,lapack and fftw, adapt as needed
-linalg="-lblas -llapack"
-fftw="-lfftw3"
-
 here=$(pwd)
 mod_name=total_energy
 mkdir -p $here/libs
@@ -55,8 +68,8 @@ cp $root_dir/XClib/xc_lib.a $here/libs/libxclib.a
 # seems.
 ar rcs $here/libs/liballobjs.a $pwobjs $utilobjs $modobjs
 
-FC="mpifort" \
-CC="mpicc" \
+FC="$f_compiler" \
+CC="$c_compiler" \
 FFLAGS="-I$here/libs -I$pw_src_path $qe_inc_dirs" \
 LDFLAGS="-L$here/libs -L$pw_src_path $qe_lib_dirs" \
 python3 -m numpy.f2py \

--- a/external_modules/total_energy_module/build_total_energy_module.sh
+++ b/external_modules/total_energy_module/build_total_energy_module.sh
@@ -58,24 +58,27 @@ echo "qe_inc_dirs: $qe_inc_dirs"
 
 here=$(pwd)
 mod_name=total_energy
-mkdir -p $here/libs
+tmp_lib_dir=$here/libs
+meson_builddir=$here/meson_builddir
+rm -rf $tmp_lib_dir $meson_builddir
 
+mkdir -p $tmp_lib_dir
 # xc_lib.a needs to be called lib<someting>.a to be linkable with -l<something>
 cp $root_dir/XClib/xc_lib.a $here/libs/libxclib.a
 
 # Stick all object files into a static lib so that we can link them, just
 # specifying them on the f2py CLI doesn't work with the meson backend, as it
 # seems.
-ar rcs $here/libs/liballobjs.a $pwobjs $utilobjs $modobjs
+ar rcs $tmp_lib_dir/liballobjs.a $pwobjs $utilobjs $modobjs
 
 FC="$f_compiler" \
 CC="$c_compiler" \
-FFLAGS="-I$here/libs -I$pw_src_path $qe_inc_dirs" \
-LDFLAGS="-L$here/libs -L$pw_src_path $qe_lib_dirs" \
+FFLAGS="-I$tmp_lib_dir -I$pw_src_path $qe_inc_dirs" \
+LDFLAGS="-L$tmp_lib_dir -L$pw_src_path $qe_lib_dirs" \
 python3 -m numpy.f2py \
     --backend meson \
     --dep mpi \
-    --build-dir meson_builddir \
+    --build-dir $meson_builddir \
     -c ${mod_name}.f90 \
     -m $mod_name \
     $linalg \
@@ -85,7 +88,7 @@ python3 -m numpy.f2py \
 
 # Workaround for f2py+meson+mpi bug
 # (https://github.com/numpy/numpy/issues/28902)
-cd meson_builddir
+cd $meson_builddir
 sed -i -re "s/dependency\('mpi'\)/dependency\('mpi', language: 'fortran')/" meson.build
 meson setup --reconfigure bbdir
 meson compile -C bbdir

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,14 @@
 # such that a pre-installed torch is not found.
 torch
 
+# We need a recent numpy to build external_modules/total_energy_module using
+# numpy's f2py. See
+# https://github.com/mala-project/mala/issues/559#issuecomment-2864133103
+# for details.
+numpy >= 2
+
 ase
 mpmath
-numpy
 optuna
 scipy
 pandas


### PR DESCRIPTION
Note that we will now require numpy 2.x for this (see 7da7d3fa3949841badd6b6fb08659c86f9a133c1).